### PR TITLE
Fix spelling of hexadecimal

### DIFF
--- a/doc/tutorial.qbk
+++ b/doc/tutorial.qbk
@@ -978,12 +978,12 @@ the input they match unless otherwise stated in the table below.]
      []]
 
     [[ _hex_ ]
-     [ Matches a hexidecimal unsigned integral value. ]
+     [ Matches a hexadecimal unsigned integral value. ]
      [ `unsigned int` ]
      [ For example, _hex_ would match `"ff"`, and generate an attribute of `255u`. ]]
 
     [[ `_hex_(arg0)` ]
-     [ Matches exactly the hexidecimal unsigned integral value `_RES_np_(arg0)`. ]
+     [ Matches exactly the hexadecimal unsigned integral value `_RES_np_(arg0)`. ]
      [ `unsigned int` ]
      []]
 
@@ -1115,7 +1115,7 @@ after the type parameter.  They are `Radix`, `MinDigits`, and `MaxDigits`.
 `Radix` defaults to `10`, `MinDigits` to `1`, and `MaxDigits` to `-1`, which
 is a sentinel value meaning that there is no max number of digits.
 
-So, if you wanted to parse exactly eight hexidecimal digits in a row in order
+So, if you wanted to parse exactly eight hexadecimal digits in a row in order
 to recognize Unicode character literals like C++ has (e.g. `\Udeadbeef`), you
 could use this parser for the digits at the end:
 
@@ -2726,9 +2726,9 @@ that will read well in error messages like this.  For instance, the JSON
 examples have these rules:
 
     bp::rule<class escape_seq, uint32_t> const escape_seq =
-        "\\uXXXX hexidecimal escape sequence";
+        "\\uXXXX hexadecimal escape sequence";
     bp::rule<class escape_double_seq, uint32_t, double_escape_locals> const
-        escape_double_seq = "\\uXXXX hexidecimal escape sequence";
+        escape_double_seq = "\\uXXXX hexadecimal escape sequence";
     bp::rule<class single_escaped_char, uint32_t> const single_escaped_char =
         "'\"', '\\', '/', 'b', 'f', 'n', 'r', or 't'";
 
@@ -2738,7 +2738,7 @@ Some things to note:
   end-user who is trying to figure out why their input failed to parse, it
   doesn't matter which kind of result a parser rule gernerates.  They just
   want to know how to fix their input.  For either rule, the fix is the same:
-  put a hexidecimal escape sequence there.
+  put a hexadecimal escape sequence there.
 
 - `single_escaped_char` has a terrible-looking name.  However, it's not really
   used as a name anywhere per se.  In error messages, it works nicely, though.

--- a/example/callback_json.cpp
+++ b/example/callback_json.cpp
@@ -44,11 +44,11 @@ namespace json {
     bp::rule<class string_char, uint32_t> const string_char =
         "code point (code points <= U+001F must be escaped)";
     bp::rule<class four_hex_digits, uint32_t> const hex_4 =
-        "four hexidecimal digits";
+        "four hexadecimal digits";
     bp::rule<class escape_seq, uint32_t> const escape_seq =
-        "\\uXXXX hexidecimal escape sequence";
+        "\\uXXXX hexadecimal escape sequence";
     bp::rule<class escape_double_seq, uint32_t, double_escape_locals> const
-        escape_double_seq = "\\uXXXX hexidecimal escape sequence";
+        escape_double_seq = "\\uXXXX hexadecimal escape sequence";
     bp::rule<class single_escaped_char, uint32_t> const single_escaped_char =
         "'\"', '\\', '/', 'b', 'f', 'n', 'r', or 't'";
 

--- a/example/json.cpp
+++ b/example/json.cpp
@@ -54,7 +54,7 @@ namespace json {
 
     // Here are all the rules declared.  I've given them names that are
     // end-user friendly, so that if there is a parse error, you get a message
-    // like "expected four hexidecimal digits here:", instead of "expected
+    // like "expected four hexadecimal digits here:", instead of "expected
     // hex_4 here:".
 
     bp::rule<class ws> const ws = "whitespace";
@@ -62,11 +62,11 @@ namespace json {
     bp::rule<class string_char, uint32_t> const string_char =
         "code point (code points <= U+001F must be escaped)";
     bp::rule<class four_hex_digits, uint32_t> const hex_4 =
-        "four hexidecimal digits";
+        "four hexadecimal digits";
     bp::rule<class escape_seq, uint32_t> const escape_seq =
-        "\\uXXXX hexidecimal escape sequence";
+        "\\uXXXX hexadecimal escape sequence";
     bp::rule<class escape_double_seq, uint32_t, double_escape_locals> const
-        escape_double_seq = "\\uXXXX hexidecimal escape sequence";
+        escape_double_seq = "\\uXXXX hexadecimal escape sequence";
     bp::rule<class single_escaped_char, uint32_t> const single_escaped_char =
         "'\"', '\\', '/', 'b', 'f', 'n', 'r', or 't'";
 
@@ -155,7 +155,7 @@ namespace json {
     // integer parsers int_parser and uint_parser.  In this case, we don't
     // want to use boost::parser::hex directly, since it has a variable number
     // of digits.  We want to match exactly 4 digits, and this is how we
-    // declare a hexidecimal parser that matches exactly 4.
+    // declare a hexadecimal parser that matches exactly 4.
     bp::parser_interface<bp::uint_parser<uint32_t, 16, 4, 4>> const hex_4_def;
 
     // We use > here instead of >>, because once we see \u, we know that

--- a/include/boost/parser/parser.hpp
+++ b/include/boost/parser/parser.hpp
@@ -5619,7 +5619,7 @@ namespace boost { namespace parser {
         attribute.  To parse a particular value `x`, use `oct(x)`. */
     inline constexpr parser_interface<uint_parser<unsigned int, 8>> oct;
 
-    /** The hexidecimal unsigned integer parser.  Produces an `unsigned int`
+    /** The hexadecimal unsigned integer parser.  Produces an `unsigned int`
         attribute.  To parse a particular value `x`, use `hex(x)`. */
     inline constexpr parser_interface<uint_parser<unsigned int, 16>> hex;
 


### PR DESCRIPTION
The library and documentation misspells it (consistently, which is good :)) as hexidecimal. That makes it hard for (new) users to find out by searching documentation.

The fifteen spots fixed:

    example/callback_json.cpp|47 col 15| "four hexidecimal digits";
    example/callback_json.cpp|49 col 18| "\\uXXXX hexidecimal escape sequence";
    example/callback_json.cpp|51 col 38| escape_double_seq = "\\uXXXX hexidecimal escape sequence";
    example/json.cpp|57 col 28| // like "expected four hexidecimal digits here:", instead of "expected
    example/json.cpp|65 col 15| "four hexidecimal digits";
    example/json.cpp|67 col 18| "\\uXXXX hexidecimal escape sequence";
    example/json.cpp|69 col 38| escape_double_seq = "\\uXXXX hexidecimal escape sequence";
    example/json.cpp|158 col 18| // declare a hexidecimal parser that matches exactly 4.
    doc/tutorial.qbk|981 col 18| [ Matches a hexidecimal unsigned integral value. ]
    doc/tutorial.qbk|986 col 28| [ Matches exactly the hexidecimal unsigned integral value `_RES_np_(arg0)`. ]
    doc/tutorial.qbk|1118 col 42| So, if you wanted to parse exactly eight hexidecimal digits in a row in order
    doc/tutorial.qbk|2729 col 18| "\\uXXXX hexidecimal escape sequence";
    doc/tutorial.qbk|2731 col 38| escape_double_seq = "\\uXXXX hexidecimal escape sequence";
    doc/tutorial.qbk|2741 col 9| put a hexidecimal escape sequence there.
    include/boost/parser/parser.hpp|5622 col 13| /** The hexidecimal unsigned integer parser.  Produces an `unsigned int`

The one spot that was inconsistent (outside the gtest subtree):

    include/boost/parser/tuple.hpp|66 col 36| // 0xDEADBEEF (hexadecimal)