### PR TITLE
Replace deprecated/removed cmake modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,6 @@ endif()
 ##################################################
 include(dependencies)
 
-find_package(Python3 COMPONENTS Interpreter)
-if (Python3_Interpreter_FOUND)
-    message("-- Found Python ${Python3_VERSION} (${Python3_EXECUTABLE})")
-endif ()
 
 
 ##################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,9 @@ endif()
 ##################################################
 include(dependencies)
 
-find_package(PythonInterp)
-if (PYTHONINTERP_FOUND)
-    message("-- Found Python ${PYTHON_VERSION_STRING} (${PYTHON_EXECUTABLE})")
+find_package(Python3 COMPONENTS Interpreter)
+if (Python3_Interpreter_FOUND)
+    message("-- Found Python ${Python3_VERSION} (${Python3_EXECUTABLE})")
 endif ()
 
 


### PR DESCRIPTION
Fixes: "Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
the cmake_policy command to set the policy and suppress this warning."

[PythonInterp was deprecated in 3.12 and removed in 3.27](https://cmake.org/cmake/help/latest/module/FindPythonInterp.html)