### PR TITLE
WIN32: fix boost build b2.exe for non-msvc compilers

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -25,7 +25,9 @@ add_custom_command(
     https://github.com/boostorg/boost.git boost_root
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
-if (MSVC)
+# MSVC determines the compiler and not the target platform
+# here we need to check WIN32
+if (WIN32)
   set(b2_exe b2.exe)
 else()
   set(b2_exe b2)
@@ -39,8 +41,29 @@ add_custom_target(boost_clone_deps
   VERBATIM)
 add_dependencies(boost_clone_deps boost_clone_superproject)
 
-if (MSVC)
-  set(bootstrap_cmd ./bootstrap.bat)
+
+if (WIN32)
+  # Windows:
+  # in order to build 'b2_exe' with the same toolset as configured in the current cmake run,
+  # we need to tell the boost bootstrap process and pass some parameters
+  # - as first parameter msvc, gcc or clang for the compiler type
+  # - additionally, for non-MSVC we need to set the environment variable CXX to the compiler: ${CMAKE_CXX_COMPILER} which
+  #   is a fully qualified path name, so that the compiler can be found by the bootstrap_cmd
+  # calling b2.exe should work also for non-MSVC compilers, as during the build, the runtime directory is part of the search PATH
+
+  if (MSVC OR CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
+    message(STATUS "configure BOOST for Visual Studio built-in compilers (i.e cl, clang-cl and clang")
+    set(bootstrap_cmd ./bootstrap.bat msvc)
+    # here we do not need to distinguish the different compilers as only the frontend is different
+  elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(STATUS "configure BOOST for Clang compiler")
+    set(bootstrap_cmd ./bootstrap.bat clang)
+    set(COMMAND_ENV set CXX=${CMAKE_CXX_COMPILER})
+  elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    message(STATUS "configure BOOST for GCC compiler")
+    set(bootstrap_cmd ./bootstrap.bat gcc)
+    set(COMMAND_ENV set CXX=${CMAKE_CXX_COMPILER})
+  endif ()
 else()
   # windres produces relocations that are rejected
   # by stricter ld configurations used in some distros
@@ -57,6 +80,7 @@ add_custom_command(
   COMMAND git submodule init libs/headers
   COMMAND git submodule init tools/boost_install
   COMMAND git submodule update --jobs 3 --depth 100
+  COMMAND ${COMMAND_ENV}
   COMMAND ${bootstrap_cmd}
   COMMAND ./b2 headers
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost_root)


### PR DESCRIPTION
propagate the selected compiler from cmake down to the boost bootstrap process
without these correction the boost bootstrap build of b2 will fail on windows with e.g. clang
for clang 'if(MSVC)' is false and the build process assumes a unix style shell and the build process fails
I'm using Clion (Jetbrains) IDE for Multiplatform development on macOS, Linux and Windows, which makes it very easy to switch between different compilers and test Code compatibility