### PR TITLE
Fix ci build issues with fedora and windows

### DIFF
--- a/include/boost/parser/config.hpp
+++ b/include/boost/parser/config.hpp
@@ -80,7 +80,7 @@
 #endif
 
 #if defined(__cpp_lib_concepts) && !defined(BOOST_PARSER_DISABLE_CONCEPTS) &&  \
-    (!defined(__clang__) || 16 <= __clang__)
+    (!defined(__clang__) || 16 <= __clang_major__)
 #    define BOOST_PARSER_USE_CONCEPTS 1
 #else
 #    define BOOST_PARSER_USE_CONCEPTS 0

--- a/include/boost/parser/detail/stl_interfaces/view_adaptor.hpp
+++ b/include/boost/parser/detail/stl_interfaces/view_adaptor.hpp
@@ -18,7 +18,7 @@
 #if !defined(BOOST_STL_INTERFACES_DOXYGEN)
 
 #if BOOST_PARSER_USE_CONCEPTS && defined(__cpp_lib_ranges) &&                  \
-    202202L <= __cpp_lib_ranges
+    202202L <= __cpp_lib_ranges && !defined(_MSC_VER)
 #define BOOST_PARSER_USE_CPP23_STD_RANGE_ADAPTOR_CLOSURE 1
 #else
 #define BOOST_PARSER_USE_CPP23_STD_RANGE_ADAPTOR_CLOSURE 0

--- a/include/boost/parser/detail/text/transcode_view.hpp
+++ b/include/boost/parser/detail/text/transcode_view.hpp
@@ -176,21 +176,24 @@ namespace boost::parser::detail { namespace text {
             requires std::sentinel_for<sentinel_type, std::ranges::iterator_t<detail::maybe_const<OtherConst, V>>>
 #endif
         friend constexpr bool operator==(const iterator<OtherConst> & x,
-                                         const sentinel & y);
+                                         const sentinel & y)
+            { return x.it_ == y.end_; }
 
         template<bool OtherConst>
 #if BOOST_PARSER_DETAIL_TEXT_USE_CONCEPTS
             requires std::sized_sentinel_for<sentinel_type, std::ranges::iterator_t<detail::maybe_const<OtherConst, V>>>
 #endif
         friend constexpr detail::range_difference_t<detail::maybe_const<OtherConst, V>>
-        operator-(const iterator<OtherConst> & x, const sentinel & y);
+        operator-(const iterator<OtherConst> & x, const sentinel & y)
+            { return x.it_ - y.end_; }
 
         template<bool OtherConst>
 #if BOOST_PARSER_DETAIL_TEXT_USE_CONCEPTS
             requires std::sized_sentinel_for<sentinel_type, std::ranges::iterator_t<detail::maybe_const<OtherConst, V>>>
 #endif
         friend constexpr detail::range_difference_t<detail::maybe_const<OtherConst, V>>
-        operator-(const sentinel & y, const iterator<OtherConst> & x);
+        operator-(const sentinel & y, const iterator<OtherConst> & x)
+            { return y.end_ - x.it_; }
 
     public:
         constexpr iterator() = default;

--- a/test/replace.cpp
+++ b/test/replace.cpp
@@ -37,7 +37,7 @@ namespace deduction {
 // MSVC and older Clangs produce hard errors here, so ill_formed does not
 // work.
 #if defined(__cpp_char8_t) && !defined(_MSC_VER) &&                            \
-    (!defined(__clang__) || 16 <= __clang__)
+    (!defined(__clang__) || 16 <= __clang_major__)
 char const empty_str[] = "";
 
 template<typename T>


### PR DESCRIPTION
this PR would fix the issues with the CI system (Fedora GCC-14), Windows MSVC 2022 c++23 and additionally a compiler error for test/search.cpp with certain clang compilers for c++23 (see also #168)
All 3 issues have a separate git commit.
However, I'm not 100% certain, if the fixes are appropriate for your intentions or coding style