### PR TITLE
char8_type -> unsigned char in UTF8 -> UTF32 implementation in

### DIFF
--- a/include/boost/parser/detail/text/transcode_iterator.hpp
+++ b/include/boost/parser/detail/text/transcode_iterator.hpp
@@ -2888,7 +2888,7 @@ namespace boost::parser::detail { namespace text {
             */
                 // clang-format on
 
-                char8_type curr_c = char8_type(cp);
+                unsigned char curr_c = (unsigned char)cp;
 
                 auto error = [&]() {
                     return ErrorHandler{}("Ill-formed UTF-8.");


### PR DESCRIPTION
utf_iterator::decode_code_point() to mitigate warnings.

Fixes #167.