### PR TITLE
Remove the broken use of alias CTAD from the transcoding views.

### DIFF
--- a/include/boost/parser/detail/text/config.hpp
+++ b/include/boost/parser/detail/text/config.hpp
@@ -18,15 +18,6 @@
 #    define BOOST_PARSER_DETAIL_TEXT_USE_CONCEPTS 1
 #endif
 
-// GCC 12 claims to support 201907L <= __cpp_deduction_guides, but does not.
-#if BOOST_PARSER_DETAIL_TEXT_USE_CONCEPTS && defined(__cpp_deduction_guides) &&    \
-    201907L <= __cpp_deduction_guides && (!defined(__GNUC__) || 13 <= __GNUC__) && \
-    !defined(_MSC_VER)
-#define BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD 1
-#else
-#define BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD 0
-#endif
-
 #if BOOST_PARSER_USE_CONCEPTS
 namespace boost::parser::detail { namespace text { namespace detail {
     inline constexpr auto begin = std::ranges::begin;

--- a/include/boost/parser/detail/text/transcode_iterator_fwd.hpp
+++ b/include/boost/parser/detail/text/transcode_iterator_fwd.hpp
@@ -51,51 +51,6 @@ namespace boost::parser::detail { namespace text {
 #endif
     class utf_iterator;
 
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-
-    template<
-        utf8_iter I,
-        std::sentinel_for<I> S = I,
-        transcoding_error_handler ErrorHandler = use_replacement_character>
-    using utf_8_to_16_iterator =
-        utf_iterator<format::utf8, format::utf16, I, S, ErrorHandler>;
-    template<
-        utf16_iter I,
-        std::sentinel_for<I> S = I,
-        transcoding_error_handler ErrorHandler = use_replacement_character>
-    using utf_16_to_8_iterator =
-        utf_iterator<format::utf16, format::utf8, I, S, ErrorHandler>;
-
-
-    template<
-        utf8_iter I,
-        std::sentinel_for<I> S = I,
-        transcoding_error_handler ErrorHandler = use_replacement_character>
-    using utf_8_to_32_iterator =
-        utf_iterator<format::utf8, format::utf32, I, S, ErrorHandler>;
-    template<
-        utf32_iter I,
-        std::sentinel_for<I> S = I,
-        transcoding_error_handler ErrorHandler = use_replacement_character>
-    using utf_32_to_8_iterator =
-        utf_iterator<format::utf32, format::utf8, I, S, ErrorHandler>;
-
-
-    template<
-        utf16_iter I,
-        std::sentinel_for<I> S = I,
-        transcoding_error_handler ErrorHandler = use_replacement_character>
-    using utf_16_to_32_iterator =
-        utf_iterator<format::utf16, format::utf32, I, S, ErrorHandler>;
-    template<
-        utf32_iter I,
-        std::sentinel_for<I> S = I,
-        transcoding_error_handler ErrorHandler = use_replacement_character>
-    using utf_32_to_16_iterator =
-        utf_iterator<format::utf32, format::utf16, I, S, ErrorHandler>;
-
-#endif
-
 }}
 
 #endif

--- a/include/boost/parser/detail/text/transcode_view.hpp
+++ b/include/boost/parser/detail/text/transcode_view.hpp
@@ -266,11 +266,6 @@ namespace boost::parser::detail { namespace text {
             { return y.end_ - x.it_; }
     };
 
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    template<class R, auto F>
-    project_view(R &&) -> project_view<std::views::all_t<R>, F>;
-#endif
-
     namespace detail {
 #if BOOST_PARSER_DETAIL_TEXT_USE_CONCEPTS
         template<auto F>
@@ -293,11 +288,7 @@ namespace boost::parser::detail { namespace text {
 #endif
             [[nodiscard]] constexpr auto operator()(R && r) const
             {
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-                return project_view_type(std::forward<R>(r));
-#else
                 return project_view_type<R>(std::forward<R>(r));
-#endif
             }
         };
     }
@@ -308,17 +299,6 @@ namespace boost::parser::detail { namespace text {
     template<typename F>
 #endif
     constexpr detail::project_impl<F> project{};
-
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-
-    template<class V>
-    using char8_view = project_view<V, detail::cast_to_charn<char8_t>{}>;
-    template<class V>
-    using char16_view = project_view<V, detail::cast_to_charn<char16_t>{}>;
-    template<class V>
-    using char32_view = project_view<V, detail::cast_to_charn<char32_t>{}>;
-
-#else
 
 #if defined(__cpp_char8_t)
 #if BOOST_PARSER_DETAIL_TEXT_USE_CONCEPTS
@@ -399,8 +379,6 @@ namespace boost::parser::detail { namespace text {
     char16_view(R &&) -> char16_view<detail::all_t<R>>;
     template<class R>
     char32_view(R &&) -> char32_view<detail::all_t<R>>;
-#endif
-
 #endif
 
     namespace detail {
@@ -610,20 +588,6 @@ namespace boost::parser::detail { namespace text {
     };
 
 
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-
-    template<format Format, class R>
-    utf_view(R &&) -> utf_view<Format, std::views::all_t<R>>;
-
-    template<class V>
-    using utf8_view = utf_view<format::utf8, V>;
-    template<class V>
-    using utf16_view = utf_view<format::utf16, V>;
-    template<class V>
-    using utf32_view = utf_view<format::utf32, V>;
-
-#else
-
 #if BOOST_PARSER_DETAIL_TEXT_USE_CONCEPTS
     template<utf_range V>
         requires std::ranges::view<V>
@@ -679,16 +643,12 @@ namespace boost::parser::detail { namespace text {
         {}
     };
 
-#if !BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
     template<class R>
     utf8_view(R &&) -> utf8_view<detail::all_t<R>>;
     template<class R>
     utf16_view(R &&) -> utf16_view<detail::all_t<R>>;
     template<class R>
     utf32_view(R &&) -> utf32_view<detail::all_t<R>>;
-#endif
-
-#endif
 
 #if defined(BOOST_TEXT_DOXYGEN)
 
@@ -821,7 +781,6 @@ namespace std::ranges {
     inline constexpr bool enable_borrowed_range<boost::parser::detail::text::utf_view<Format, V>> =
         enable_borrowed_range<V>;
 
-#if !BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
     template<class V>
     inline constexpr bool enable_borrowed_range<boost::parser::detail::text::utf8_view<V>> =
         enable_borrowed_range<V>;
@@ -831,7 +790,6 @@ namespace std::ranges {
     template<class V>
     inline constexpr bool enable_borrowed_range<boost::parser::detail::text::utf32_view<V>> =
         enable_borrowed_range<V>;
-#endif
 }
 
 #endif

--- a/include/boost/parser/transcode_view.hpp
+++ b/include/boost/parser/transcode_view.hpp
@@ -13,17 +13,6 @@ namespace boost::parser {
 
     using format = detail::text::format;
 
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-
-    template<class V>
-    using utf8_view = detail::text::utf_view<format::utf8, V>;
-    template<class V>
-    using utf16_view = detail::text::utf_view<format::utf16, V>;
-    template<class V>
-    using utf32_view = detail::text::utf_view<format::utf32, V>;
-
-#else
-
     /** A view that produces UTF-8 from an given sequence of UTF.
 
         \tparam V Constrained by `std::ranges::view<V>`.  Additionally, the
@@ -103,8 +92,6 @@ namespace boost::parser {
     utf16_view(R &&) -> utf16_view<std::views::all_t<R>>;
     template<class R>
     utf32_view(R &&) -> utf32_view<std::views::all_t<R>>;
-#endif
-
 #endif
 
     /** A view adaptor that produces a `utf8_view` of the given view. */

--- a/test/transform_replace.cpp
+++ b/test/transform_replace.cpp
@@ -201,13 +201,6 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u8string, decltype(f_u16str), attr_t>
         u8_u16_shim(f_u16str);
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u8_u16_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf8,
-                      std::ranges::owning_view<std::u16string>> &>);
-#endif
     static_assert(bp::detail::transform_replacement_for<
                   decltype(u8_u16_shim),
                   std::u8string,
@@ -215,13 +208,6 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u8string, decltype(f_u16str_ref), attr_t>
         u8_u16_ref_shim(f_u16str_ref);
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u8_u16_ref_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf8,
-                      std::ranges::ref_view<std::u16string>> &>);
-#endif
     static_assert(bp::detail::transform_replacement_for<
                   decltype(u8_u16_ref_shim),
                   std::u8string,
@@ -231,13 +217,6 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u8string, decltype(f_u32str), attr_t>
         u8_u32_shim(f_u32str);
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u8_u32_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf8,
-                      std::ranges::owning_view<std::u32string>> &>);
-#endif
     static_assert(bp::detail::transform_replacement_for<
                   decltype(u8_u32_shim),
                   std::u8string,
@@ -245,13 +224,6 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u8string, decltype(f_u32str_ref), attr_t>
         u8_u32_ref_shim(f_u32str_ref);
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u8_u32_ref_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf8,
-                      std::ranges::ref_view<std::u32string>> &>);
-#endif
     static_assert(bp::detail::transform_replacement_for<
                   decltype(u8_u32_ref_shim),
                   std::u8string,
@@ -261,13 +233,6 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u16string, decltype(f_u8str), attr_t>
         u16_u8_shim(f_u8str);
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u16_u8_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf16,
-                      std::ranges::owning_view<std::u8string>> &>);
-#endif
     static_assert(bp::detail::transform_replacement_for<
                   decltype(u16_u8_shim),
                   std::u16string,
@@ -275,13 +240,6 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u16string, decltype(f_u8str_ref), attr_t>
         u16_u8_ref_shim(f_u8str_ref);
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u16_u8_ref_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf16,
-                      std::ranges::ref_view<std::u8string const>> &>);
-#endif
     static_assert(bp::detail::transform_replacement_for<
                   decltype(u16_u8_ref_shim),
                   std::u16string,
@@ -291,13 +249,6 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u32string, decltype(f_u8str), attr_t>
         u32_u8_shim(f_u8str);
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u32_u8_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf32,
-                      std::ranges::owning_view<std::u8string>> &>);
-#endif
     static_assert(bp::detail::transform_replacement_for<
                   decltype(u32_u8_shim),
                   std::u32string,
@@ -305,13 +256,6 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u32string, decltype(f_u8str_ref), attr_t>
         u32_u8_ref_shim(f_u8str_ref);
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u32_u8_ref_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf32,
-                      std::ranges::ref_view<std::u8string const>> &>);
-#endif
     static_assert(bp::detail::transform_replacement_for<
                   decltype(u32_u8_ref_shim),
                   std::u32string,
@@ -341,15 +285,7 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u16string, decltype(f_u32str), attr_t>
     u16_u32_shim(f_u32str);
-#if BOOST_PARSER_USE_CONCEPTS
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u16_u32_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf16,
-                      std::ranges::owning_view<std::u32string>> &>);
-#endif
-#else
+#if !BOOST_PARSER_USE_CONCEPTS
     static_assert(
         std::is_same_v<
             decltype(u16_u32_shim(attr_t{})),
@@ -363,15 +299,7 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u16string, decltype(f_u32str_ref), attr_t>
         u16_u32_ref_shim(f_u32str_ref);
-#if BOOST_PARSER_USE_CONCEPTS
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u16_u32_ref_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf16,
-                      std::ranges::ref_view<std::u32string>> &>);
-#endif
-#else
+#if !BOOST_PARSER_USE_CONCEPTS
     static_assert(std::is_same_v<
                   decltype(u16_u32_ref_shim(attr_t{})),
                   bp::detail::text::utf16_view<
@@ -406,15 +334,7 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u32string, decltype(f_u16str), attr_t>
         u32_u16_shim(f_u16str);
-#if BOOST_PARSER_USE_CONCEPTS
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u32_u16_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf32,
-                      std::ranges::owning_view<std::u16string>> &>);
-#endif
-#else
+#if !BOOST_PARSER_USE_CONCEPTS
     static_assert(
         std::is_same_v<
             decltype(u32_u16_shim(attr_t{})),
@@ -428,15 +348,7 @@ namespace detail_utf_rvalue_shim {
 
     bp::detail::utf_rvalue_shim<std::u32string, decltype(f_u16str_ref), attr_t>
         u32_u16_ref_shim(f_u16str_ref);
-#if BOOST_PARSER_USE_CONCEPTS
-#if BOOST_PARSER_DETAIL_TEXT_USE_ALIAS_CTAD
-    static_assert(std::is_same_v<
-                  decltype(u32_u16_ref_shim(attr_t{})),
-                  bp::detail::text::utf_view<
-                      bp::detail::text::format::utf32,
-                      std::ranges::ref_view<std::u16string>> &>);
-#endif
-#else
+#if !BOOST_PARSER_USE_CONCEPTS
     static_assert(std::is_same_v<
                   decltype(u32_u16_ref_shim(attr_t{})),
                   bp::detail::text::utf32_view<


### PR DESCRIPTION
Fixes #193.